### PR TITLE
Add Default Stop ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Then add **hubot-nextbus** to your `external-scripts.json`:
 | Environment Variable    | Optional | Description                             |
 | ----------------------- | :------: | ----------------------------------------|
 | `HUBOT_NEXTBUS_LAT_LON` | No       | Default location for `hubot nextbus`, separated by a comma. (e.g. `36.1629191,-86.7813481`)|
-| `HUBOT_NEXTBUS_BASE_URL`| Yes      | URL of a `gtfs-rails-api` instance |
+| `HUBOT_NEXTBUS_STOP_ID` | Yes       | Specific identifier to use with `hubot nextbus`; if not set, falls back to latitude/longitude |
+| `HUBOT_NEXTBUS_BASE_URL`| Yes      | URL of a `gtfs-rails-api` instance; Defaults to Nashville, TN. |
 
 ## Usage
 

--- a/src/nextbus.coffee
+++ b/src/nextbus.coffee
@@ -3,7 +3,8 @@
 #
 # Configuration:
 #   HUBOT_NEXTBUS_BASE_URL - URL of a `gtfs-rails-api` instance
-#   HUBOT_NEXTBUS_LAT_LON - Default location for `hubot nextbus`
+#   HUBOT_NEXTBUS_LAT_LON - Default location for stop search
+#   HUBOT_NEXTBUS_STOP_ID - Default stop for `hubot nextbus`
 #
 # Commands:
 #   hubot nextbus
@@ -18,10 +19,15 @@ moment = require('moment')
 AsciiTable = require('ascii-table')
 baseURL = process.env.HUBOT_NEXTBUS_BASE_URL || 'https://gtfs.transitnownash.org'
 latlon = process.env.HUBOT_NEXTBUS_LAT_LON
+defaultStopId = process.env.HUBOT_NEXTBUS_STOP_ID
 
 module.exports = (robot) ->
-  # query the default location's closest bus stop
+  # query the default stop ID or location's closest bus stop
   robot.respond /(?:bus|nextbus)(?: me)?$/i, (msg) ->
+    if defaultStopId
+      queryStopById stop_id, msg
+      return
+
     getAPIResponse "stops/near/#{latlon}/1000.json?per_page=5", msg, (stops) ->
       if stops.total > 0
         queryStopById stops.data[0].stop_gid, msg

--- a/test/nextbus_test.coffee
+++ b/test/nextbus_test.coffee
@@ -26,7 +26,7 @@ describe 'hubot-nextbus', ->
     nock.cleanAll()
     Date.now = originalDateNow
 
-  context 'regular tests', ->
+  context 'regular tests with latitude/longitude set', ->
     beforeEach ->
       Date.now = () ->
         return Date.parse('Fri, 1 Oct 2021 12:00:00 UTC')
@@ -81,6 +81,36 @@ describe 'hubot-nextbus', ->
             ['alice', '@hubot nextbus stops']
             ['hubot', 'List of nearby stops:']
             ['hubot', '- [CHA7AWN] CHARLOTTE AVE & 7TH AVE N WB\n- [CHA7AEN] CHARLOTTE AVE & 7TH AVE N EB\n- [6AVDEASN] 6TH AVE & DEADERICK ST SB\n- [6AVDEANN] 6TH AVE N & DEADERICK ST NB\n- [UNI7AWN] UNION ST & 7TH AVE N WB']
+          ]
+          done()
+        catch err
+          done err
+        return
+      , 1000)
+
+  context 'regular tests with default stop ID set', ->
+    beforeEach ->
+      Date.now = () ->
+        return Date.parse('Fri, 1 Oct 2021 12:00:00 UTC')
+      process.env.HUBOT_NEXTBUS_LAT_LON = '0,0'
+      process.env.HUBOT_NEXTBUS_STOP_ID = 'CHA7AWN'
+      @room = helper.createRoom()
+
+    afterEach ->
+      @room.destroy()
+      delete process.env.HUBOT_NEXTBUS_LAT_LON
+      delete process.env.HUBOT_NEXTBUS_STOP_ID
+
+    # hubot nextbus
+    it 'returns the next bus for closest stop', (done) ->
+      selfRoom = @room
+      selfRoom.user.say('alice', '@hubot nextbus')
+      setTimeout(() ->
+        try
+          expect(selfRoom.messages).to.eql [
+            ['alice', '@hubot nextbus']
+            ['hubot', 'Upcoming Trips for [CHA7AWN] CHARLOTTE AVE & 7TH AVE N WB']
+            ['hubot', '  7:01 AM   #50 - CHARLOTTE WALMART            in a minute    \n  7:15 AM   #17 - GREEN HILLS VIA 12TH AVE S   in 16 minutes  \n  7:16 AM   #50 - CHARLOTTE WALMART            in 16 minutes  \n  7:31 AM   #50 - CHARLOTTE WALMART            in 31 minutes  \n  7:35 AM   #17 - GREEN HILLS VIA 12TH AVE S   in 36 minutes  ']
           ]
           done()
         catch err


### PR DESCRIPTION
Prior to this PR, only the latitude/longitude was used for getting the next bus times. This PR allows the administrator to configure a single stop ID for the default `hubot nextbus` behavior.